### PR TITLE
Remove Docker Hub credentials

### DIFF
--- a/aws/rails/build_from_travis.sh
+++ b/aws/rails/build_from_travis.sh
@@ -11,8 +11,5 @@ elif [ "${TRAVIS_BRANCH}" != "master"]; then
   exit 0
 fi
 
-echo "Setting Docker Hub credentials..."
-docker login --email=$DOCKER_EMAIL --password=$DOCKER_PASSWORD --username=$DOCKER_USERNAME
-
 echo "Building and pushing the production Rails image..."
 sudo aws/rails/build.sh


### PR DESCRIPTION
This isn't needed anymore after moving to a public repository.
