### PR TITLE
Experiment with introducing React and Babel, hacking on profile page (WIP)

### DIFF
--- a/webpack/config/webpack.config.shared.js
+++ b/webpack/config/webpack.config.shared.js
@@ -14,7 +14,11 @@ module.exports = {
       { test: /\.scss$/, loaders: ["style", "css", "sass"] },
       { test: /\.png$/, loader: 'url-loader?limit=100000' },
       { test: /\.jpg$/, loader: 'file-loader' },
-      { test: /\.svg$/, loader: 'file-loader' }
+      { test: /\.svg$/, loader: 'file-loader' },
+      { test: /\.jsx$/, loader: 'babel', query: {
+        cacheDirectory: true,
+        presets: ['es2015', 'react', 'stage-2']
+      } }
     ]
   }
 };

--- a/webpack/package.json
+++ b/webpack/package.json
@@ -22,6 +22,7 @@
     "file-loader": "^0.8.4",
     "image-size-loader": "0.7.0",
     "react": "0.14.3",
+    "react-dom": "0.14.3",
     "babel-loader": "6.2.0",
     "babel-core": "6.2.0",
     "babel-preset-react": "6.1.18",

--- a/webpack/package.json
+++ b/webpack/package.json
@@ -20,6 +20,12 @@
     "webpack": "^1.12.3",
     "url-loader": "^0.5.6",
     "file-loader": "^0.8.4",
-    "image-size-loader": "0.7.0"
+    "image-size-loader": "0.7.0",
+    "react": "0.14.3",
+    "babel-loader": "6.2.0",
+    "babel-core": "6.2.0",
+    "babel-preset-react": "6.1.18",
+    "babel-preset-es2015": "6.1.18",
+    "babel-preset-stage-2": "6.1.18"
   }
 }

--- a/webpack/src/interventions/interventions_container.jsx
+++ b/webpack/src/interventions/interventions_container.jsx
@@ -1,8 +1,157 @@
 import React from 'react';
+var jQueryUIWrapper = require('./jquery-ui-wrapper.jsx');
 
 export default class InterventionsContainer extends React.Component {
+  constructor() {
+    super()
+    this.state = {
+      editingIntervention: null,
+      interventions: null
+    };
+  }
+
+  // TODO(kr)
+  // onInterventionSelected
+  // onAddIntervention
+  // onCancelNewIntervention
+  // onAddProgressNote
+
+  // TODO(kr) css bug here
   render() {
-    return <h1>Hello world</h1>;
+    return <div>
+      {this.renderLeftPanel()}
+      {this.renderRightPanel()}
+    </div>;
+  }
+
+  renderLeftPanel() {
+    return <div className="left-panel">
+      <div id="open-intervention-form">
+        <h1>
+          <span id="add-intervention-plus-sign">
+            +
+          </span>
+          <span id="add-intervention-text">
+            Add intervention
+          </span>
+        </h1>
+      </div>
+      <div id="intervention-cell-list">
+        TODO(kr)
+      </div>
+    </div>;
+  }
+
+  renderInterventionTypeSelector() {
+    return 'INTERVENTION TYPE SELECTOR';
+    // <select id={intervention_type_id,
+    //             options_from_collection_for_select(InterventionType.all, :id, :name),
+    //             { include_blank: " -- Intervention type -- " },
+    //             { required: true }) %>
+  }
+
+  renderRightPanel() {
+    return <div className="right-panel">
+      <div id="intervention-detail-list">
+        {!this.state.interventions || this.state.interventions.length === 0
+          ? <div>No interventions</div>
+          : this.state.interventions.map(this.renderInterventionDetails)}
+        <form>
+          <h1>Add Intervention</h1>
+          <p className="alert field errors"></p>
+          <label>Select Intervention</label>
+          {this.renderInterventionTypeSelector}
+          <label>Comment</label>
+          <textarea id="comment" placeholder="Add comment" cols="40" rows="5" />
+          <label>Goal</label>
+          <textarea id="goal" placeholder="Add goal" cols="40" rows="5" />
+          <label>End date</label>
+          <jQueryUIWrapper.DatePicker />
+          <br/><br/>
+          
+          <button id="close-intervention-form" className="btn cancel-btn" type="button">Cancel</button>
+        </form>
+      </div>
+    </div>
+  }
+
+
+          // <input type="text" <%= i.text_field :end_date class: "datepicker" placeholder: "yyyy-mm-dd",
+          //     pattern: "(19|20)[0-9]{2}(\/|-|.)((0[1-9])|(1[0-2])|([0-9]))(\/|-|.)(([0-2][0-9])|(3[0-1])|([0-9]))"
+          //     # Accepts any of the following formats: 2014-02-02 2014/02/02 2014/2/2 2014.2.2 ...
+          // %>
+
+          // <%= i.hidden_field :educator_id value: current_educator.id %>
+          // <%= i.hidden_field :student_id value: @student.id %>
+          // <%= i.submit "Save" class: "btn save-btn" %>
+
+  renderInterventionDetails() {
+    return 'INTERVENTION DETAILS';
+        //       <% if @interventions.present? %>
+        //     <% @interventions.all.each do |i| %>
+
+        //       <!-- INTERVENTION DETAILS -->
+
+        //       <div className="intervention-detail" data-id="<%= i.id %>">
+        //         <h2><%= i.intervention_type.name %></h2>
+        //         <strong>Description</strong>
+        //         <p><%= i.comment %></p>
+        //         <strong>Goal</strong>
+        //         <p><%= i.goal %></p>
+        //         <strong>Start Date</strong>
+        //         <p><%= i.start_date.strftime("%B %e %Y") %></p>
+        //         <% if i.end_date.present? %>
+        //           <strong>End Date</strong>
+        //           <p><%= i.end_date.strftime("%B %e, %Y") %></p>
+        //         <% end %>
+        //         <% if i.progress_notes.present? %>
+        //           <h2>Progress notes</h2>
+        //           <div className="progress-note-list">
+        //             <% i.progress_notes.each do |p| %>
+        //               <div className="progress-note">
+        //                 <strong>
+        //                   <%= p.educator.email %>
+        //                 </strong>
+        //                 <p>
+        //                   <%= p.content %>
+        //                   <br/>
+        //                   <span className="smalltype">
+        //                     <%= p.created_at.strftime("%B %e, %Y %l:%M %p") %>
+        //                   </span>
+        //                 </p>
+        //               </div>
+        //             <% end %>
+        //           </div>
+        //         <% else %>
+        //           <div className="progress-note-list"></div>
+        //         <% end %>
+
+        //         <!-- PROGRESS NOTES ON INTERVENTION -->
+
+        //         <button className="btn add-progress-note" type="button">
+        //           Add progress note
+        //         </button>
+
+        //         <div className="add-progress-note-area">
+        //           <h2>Add progress note</h2>
+        //           <p className="alert field errors"></p>
+        //           <%= form_for @progress_note, remote: true do |p| %>
+        //             <label>Progress note</label>
+        //             <%= p.text_area :content, cols: "40", rows: "5", required: true %>
+        //             <%= p.select(:educator_id,
+        //                   options_from_collection_for_select(Educator.all, :id, :email),
+        //                   { include_blank: " -- Select educator -- " },
+        //                   { required: true }) %>
+        //             <br/>
+        //             <%= p.hidden_field :intervention_id, value: i.id %>
+        //             <%= p.submit "Save", class: "btn save-btn" %>
+        //             <div className="btn cancel-progress-note" type="button">Cancel</div>
+        //           <% end %>
+        //         </div>
+        //       </div>
+        //     <% end %>
+        //   </div>
+        // <% end %>
   }
 }
 
@@ -10,6 +159,4 @@ export default class InterventionsContainer extends React.Component {
 // onInterventionSelected
 // onAddIntervention
 // onCancelNewIntervention
-
-
 // onAddProgressNote

--- a/webpack/src/interventions/interventions_container.jsx
+++ b/webpack/src/interventions/interventions_container.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default class InterventionsContainer extends React.Component {
+  render() {
+    return <h1>Hello world</h1>;
+  }
+}
+
+// getInitialState
+// onInterventionSelected
+// onAddIntervention
+// onCancelNewIntervention
+
+
+// onAddProgressNote

--- a/webpack/src/interventions/jquery-ui-wrapper.jsx
+++ b/webpack/src/interventions/jquery-ui-wrapper.jsx
@@ -1,0 +1,59 @@
+// We don't actually need JSX here, but this serves as a demo for how
+// to set up a package of reusable components that may use JSX.
+
+var React = require('react');
+
+function wrapWidget(name) {
+  var displayName = 'React' + name[0].toUpperCase() + name.slice(1);
+
+  return React.createClass({
+    render: function() {
+      return this.props.children;
+    },
+
+    // TODO(kr)
+    // componentDidUpdate: function(prevProps) {
+    //   if (!shallowEqual(prevProps, this.props)) {
+    //     this._runPlugin();
+    //   }
+    // },
+
+    componentDidMount: function() {
+      this._runPlugin();
+    },
+
+    _runPlugin: function() {
+      var $node = jQuery(this.getDOMNode());
+      $node[name](this.props);
+      this.$ = $node;
+    },
+
+    displayName: displayName
+  });
+}
+
+var WIDGETS = {
+  Accordion: 'accordion',
+  Autocomplete: 'autocomplete',
+  Button: 'button',
+  DatePicker: 'datepicker',
+  Draggable: 'draggable',
+  Droppable: 'droppable',
+  Menu: 'menu',
+  ProgressBar: 'progressbar',
+  Resizable: 'resizable',
+  Selectable: 'selectable',
+  Sortable: 'sortable',
+  Slider: 'slider',
+  Spinner: 'spinner',
+  Tabs: 'tabs',
+  Tooltip: 'tooltip'
+};
+
+var ReactJQueryUI = {};
+
+for (var key in WIDGETS) {
+  ReactJQueryUI[key] = wrapWidget(WIDGETS[key]);
+}
+
+module.exports = ReactJQueryUI;

--- a/webpack/src/profile.js
+++ b/webpack/src/profile.js
@@ -1,7 +1,6 @@
 var React = require('react');
-var InterventionsContainer = require('./interventions/interventions_container.jsx');
-
-
+var ReactDOM = require('react-dom');
+var InterventionsContainer = require('./interventions/interventions_container.jsx').default;
 
 (function(root) {
 
@@ -117,7 +116,6 @@ $(function() {
       InterventionsController.selectIntervention($(this));
     });
 
-
     // Tabs
     $('.tab-select').click(function() {
       var tab = $(this).data('tab');
@@ -125,15 +123,16 @@ $(function() {
       $('.tab-select').removeClass('selected');
       $(this).addClass('selected');
 
-      if (tab !== 'interventions') {
+      if (tab !== 'interventions-tab') {
         $('#' + tab).show();
         return;
       }
 
       // Interventions tab
       var interventionsTabEl = document.getElementById('interventions-tab');
-      $(interventionsTabEl).show();
-      React.render(InterventionsContainer, interventionsTabEl);
+      $(interventionsTabEl).html('').show();
+      var reactEl = React.createElement(InterventionsContainer, {});
+      ReactDOM.render(reactEl, interventionsTabEl);
     });
 
     $('.add-progress-note-area').hide();

--- a/webpack/src/profile.js
+++ b/webpack/src/profile.js
@@ -1,3 +1,8 @@
+var React = require('react');
+var InterventionsContainer = require('./interventions/interventions_container.jsx');
+
+
+
 (function(root) {
 
   var ProfileChartData = function initializeProfileChartData (name, data, color) {
@@ -112,13 +117,23 @@ $(function() {
       InterventionsController.selectIntervention($(this));
     });
 
+
     // Tabs
     $('.tab-select').click(function() {
       var tab = $(this).data('tab');
       $('.tab').hide();
       $('.tab-select').removeClass('selected');
       $(this).addClass('selected');
-      $('#' + tab).show();
+
+      if (tab !== 'interventions') {
+        $('#' + tab).show();
+        return;
+      }
+
+      // Interventions tab
+      var interventionsTabEl = document.getElementById('interventions-tab');
+      $(interventionsTabEl).show();
+      React.render(InterventionsContainer, interventionsTabEl);
     });
 
     $('.add-progress-note-area').hide();


### PR DESCRIPTION
This is work-in-progress, but shared for communicating about reworking the interventions tab in React.  To do this it also updated the build process to introduce Babel for JSX.

This is fairly incomplete, and my recommendation would be to take a more incremental step and keep some server rendering, using the approach in https://github.com/codeforamerica/somerville-teacher-tool/pull/340 as a starting point, which allows a more direct path to re-use existing Rails form helpers and jQuery UI components.  A next step after that pull request might be to introduce React for new features, and a main consideration will be ramping up on React idioms for forms versus staying with the Rails `form_for` method.
